### PR TITLE
Cross-compile linux-aarch64 on linux-64 using Azure

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -15,7 +15,7 @@ jobs:
       linux_aarch64_:
         CONFIG: linux_aarch64_
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_ppc64le_:
         CONFIG: linux_ppc64le_
         UPLOAD_PACKAGES: 'True'

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -21,7 +21,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 docker_image:
-- quay.io/condaforge/linux-anvil-aarch64
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 openssl:
 - '3'
 target_platform:

--- a/README.md
+++ b/README.md
@@ -3,11 +3,15 @@ About capnproto-feedstock
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/capnproto-feedstock/blob/main/LICENSE.txt)
 
-Home: http://capnproto.org
+Home: https://capnproto.org
 
 Package license: MIT
 
 Summary: An insanely fast data interchange format and capability-based RPC system.
+
+Development: https://github.com/capnproto/capnproto
+
+Documentation: https://capnproto.org
 
 Current build status
 ====================

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -6,6 +6,7 @@ conda_build:
   pkg_format: '2'
 build_platform:
   osx_arm64: osx_64
+  linux_aarch64: linux_64
   linux_ppc64le: linux_64
 provider:
   linux_aarch64: azure

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - fix-msvc.diff
 
 build:
-  number: 2
+  number: 3
   run_exports:
     # soname changes with every release
     # https://abi-laboratory.pro/index.php?view=timeline&l=capnproto

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -64,10 +64,13 @@ test:
     - if not exist %LIBRARY_LIB%\\kj.lib exit 1  # [win]
 
 about:
-  home: http://capnproto.org
+  home: https://capnproto.org
   license_file: LICENSE
   license: MIT
+  license_family: MIT
   summary: An insanely fast data interchange format and capability-based RPC system.
+  dev_url: https://github.com/capnproto/capnproto
+  doc_url: https://capnproto.org
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
---

Switch linux-aarch64 from an [emulated build](https://conda-forge.org/docs/maintainer/knowledge_base/#emulated-builds), which takes ~2 hours, to a cross-compiled build. The main downside is that now the test suite won't be executed, but we know from #48 that the test suite passes for the emulated build.

I didn't bump the build number. We already have a linux-aarch64 conda binary from the emulated build, so I don't see any advantage of uploading another one from the cross-compiled build (especially not enough of an advantage to justify also uploading new binaries for all the other platforms).
