### PR TITLE
Cross-compile 1.0.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.0.2" %}
+{% set version = "1.0.1" %}
 
 package:
   name: capnproto
@@ -6,13 +6,13 @@ package:
 
 source:
   url: https://github.com/capnproto/capnproto/archive/v{{ version }}.tar.gz
-  md5: 4dd1aaacff63781087e89097f9b02542
+  md5: a05c8010505f091a85b586968c0e5fbf
   patches:
     # MSVC miscompiles async.c++ file when /O2 is given
     - fix-msvc.diff
 
 build:
-  number: 3
+  number: 1
   run_exports:
     # soname changes with every release
     # https://abi-laboratory.pro/index.php?view=timeline&l=capnproto


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

---

We need capnproto 1.0.1 for tiledb-feedstock (https://github.com/conda-forge/tiledb-feedstock/pull/370). Only 1.0.2 has been cross-compiled to linux-aarch64, linux-ppc64le, and osx-arm64.

To prepare this PR I did the following:

* Created an internal branch [`1.0.1`](https://github.com/conda-forge/capnproto-feedstock/tree/1.0.1) to backport the latest feedstock updates
* Used the md5 from when the recipe version was 1.0.1 https://github.com/conda-forge/capnproto-feedstock/blob/b6d7a7465a81cac72db0b28adf71b6a5751ee463/recipe/meta.yaml
* Used build number 1 since 1.0.1 only had build number 0 https://anaconda.org/conda-forge/capnproto/files?version=1.0.1
* I left the patch that was applied to 1.0.2 to support openssl 3 (https://github.com/conda-forge/capnproto-feedstock/pull/32). Hopefully it can also be applied to 1.0.1