### PR TITLE
Do not run tests when cross-compiling

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 cdt_name:
-- cos7
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -25,7 +25,5 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-- - c_stdlib_version
-  - cdt_name
 zlib:
 - '1'

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -11,7 +11,7 @@ c_stdlib_version:
 cdt_arch:
 - aarch64
 cdt_name:
-- cos7
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -29,7 +29,5 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-- - c_stdlib_version
-  - cdt_name
 zlib:
 - '1'

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 cdt_name:
-- cos7
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -25,7 +25,5 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-- - c_stdlib_version
-  - cdt_name
 zlib:
 - '1'

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @jdblischak @LehMaxence @Shelnutt2 @ihnorton @isuruf
+* @LehMaxence @Shelnutt2 @ihnorton @isuruf @jdblischak

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -48,6 +48,9 @@ source run_conda_forge_build_setup
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
+if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]] && [[ "${HOST_PLATFORM}" != linux-* ]] && [[ "${BUILD_WITH_CONDA_DEBUG:-0}" != 1 ]]; then
+    EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
+fi
 
 
 ( endgroup "Configuring conda" ) 2> /dev/null

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -33,7 +33,7 @@ rm -rf "${MAMBA_ROOT_PREFIX}" "${micromamba_exe}" || true
 ( endgroup "Provisioning base env with micromamba" ) 2> /dev/null
 
 ( startgroup "Configuring conda" ) 2> /dev/null
-
+echo "Activating environment"
 source "${MINIFORGE_HOME}/etc/profile.d/conda.sh"
 conda activate base
 export CONDA_SOLVER="libmamba"
@@ -87,6 +87,10 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     # Drop into an interactive shell
     /bin/bash
 else
+
+    if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
+        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
+    fi
 
     conda-build ./recipe -m ./.ci_support/${CONFIG}.yaml \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \

--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -12,6 +12,7 @@
 
 setlocal enableextensions enabledelayedexpansion
 
+FOR %%A IN ("%~dp0.") DO SET "REPO_ROOT=%%~dpA"
 if "%MINIFORGE_HOME%"=="" set "MINIFORGE_HOME=%USERPROFILE%\Miniforge3"
 :: Remove trailing backslash, if present
 if "%MINIFORGE_HOME:~-1%"=="\" set "MINIFORGE_HOME=%MINIFORGE_HOME:~0,-1%"
@@ -33,13 +34,13 @@ call "%MICROMAMBA_EXE%" create --yes --root-prefix "%MAMBA_ROOT_PREFIX%" --prefi
     pip python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
 if !errorlevel! neq 0 exit /b !errorlevel!
 echo Removing %MAMBA_ROOT_PREFIX%
-del /S /Q "%MAMBA_ROOT_PREFIX%"
-del /S /Q "%MICROMAMBA_TMPDIR%"
-call :end_group
+del /S /Q "%MAMBA_ROOT_PREFIX%" >nul
+del /S /Q "%MICROMAMBA_TMPDIR%" >nul
 
 call :start_group "Configuring conda"
 
 :: Activate the base conda environment
+echo Activating environment
 call "%MINIFORGE_HOME%\Scripts\activate.bat"
 :: Configure the solver
 set "CONDA_SOLVER=libmamba"
@@ -59,6 +60,11 @@ if !errorlevel! neq 0 exit /b !errorlevel!
 if EXIST LICENSE.txt (
     echo Copying feedstock license
     copy LICENSE.txt "recipe\\recipe-scripts-license.txt"
+)
+if NOT [%HOST_PLATFORM%] == [%BUILD_PLATFORM%] (
+    if [%CROSSCOMPILING_EMULATOR%] == [] (
+        set "EXTRA_CB_OPTIONS=%EXTRA_CB_OPTIONS% --no-test"
+    )
 )
 
 if NOT [%flow_run_id%] == [] (

--- a/README.md
+++ b/README.md
@@ -205,4 +205,5 @@ Feedstock Maintainers
 * [@Shelnutt2](https://github.com/Shelnutt2/)
 * [@ihnorton](https://github.com/ihnorton/)
 * [@isuruf](https://github.com/isuruf/)
+* [@jdblischak](https://github.com/jdblischak/)
 

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -11,3 +11,4 @@ build_platform:
 provider:
   linux_aarch64: azure
   linux_ppc64le: azure
+test: native_and_emulated

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,13 +41,13 @@ test:
   source_files:
     - c++/samples
   commands:
-    - capnp --help  # [not (osx and arm64)]
-    - capnpc --help  # [not (osx and arm64)]
-    - capnpc-c++ --help  # [not (osx and arm64)]
-    - capnpc-capnp --help  # [not (osx and arm64)]
+    - capnp --help
+    - capnpc --help
+    - capnpc-c++ --help
+    - capnpc-capnp --help
 
-    - capnpc -I"$PREFIX/include" -oc++ c++/samples/addressbook.capnp  # [unix and (not (osx and arm64))]
-    - test -f c++/samples/addressbook.capnp.c++  # [unix and (not (osx and arm64))]
+    - capnpc -I"$PREFIX/include" -oc++ c++/samples/addressbook.capnp  # [unix]
+    - test -f c++/samples/addressbook.capnp.c++  # [unix]
 
     - capnpc -I"%LIBRARY_INC%" -oc++ c++/samples/addressbook.capnp  # [win]
     - if not exist c++/samples/addressbook.capnp.c++ exit 1  # [win]


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

---

I didn't realize the default was to [run the test section for all builds](https://conda-forge.org/docs/maintainer/conda_forge_yml/#test).

I confirmed that the [cross-compiled linux builds](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=1073863&view=logs&j=76d26bd9-dbb3-560d-6d10-33f27642e45e&t=956f2f3c-0fa2-593c-d164-3da7ee40b74b) did attempt to run the test suite. While this appears to have failed as expected, frustratingly it didn't generate an error.

```
kj/filesystem-disk-unix.c++:1681: warning: root dir file descriptor is broken, probably because of qemu; compensating
kj/filesystem-disk-unix.c++:1681: warning: root dir file descriptor is broken, probably because of qemu; compensating
```

I've updated the recipe to only run the test section for native and emulated builds. Thus we no longer need to use jinja2 variables to skip the tests for cross-compiled builds.

I don't expect the rerendering to affect the build hash. But if it does, I'll bump the build number.

xref: https://github.com/conda-forge/capnproto-feedstock/pull/58#discussion_r1836886551